### PR TITLE
Porting https://github.com/senaite/bika.lims/pull/397 into senaite.api

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,11 @@
+1.0.1 (2017-11-24)
+------------------
+
+- #390(bika.lims) Remove log verbosity of UIDReference.get when value is None
+ or
+empty
+- #397(bika.lims) Fix Issue-396: AttributeError: uid_catalog on AR publication
+
 1.0.1 (2017-09-30)
 ------------------
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,4 +1,4 @@
-1.0.1 (2017-11-24)
+1.0.2 (2017-11-24)
 ------------------
 
 - #397(bika.lims) Fix Issue-396: AttributeError: uid_catalog on AR publication

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,9 +1,6 @@
 1.0.1 (2017-11-24)
 ------------------
 
-- #390(bika.lims) Remove log verbosity of UIDReference.get when value is None
- or
-empty
 - #397(bika.lims) Fix Issue-396: AttributeError: uid_catalog on AR publication
 
 1.0.1 (2017-09-30)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = '1.0.1'
+version = '1.0.2'
 
 
 setup(

--- a/src/senaite/api/__init__.py
+++ b/src/senaite/api/__init__.py
@@ -135,7 +135,7 @@ def get_tool(name, context=None, default=_marker):
         try:
             context = get_object(context)
             return getToolByName(context, name)
-        except (BikaLIMSError, AttributeError) as e:
+        except (SenaiteAPIError, AttributeError) as e:
             # https://github.com/senaite/bika.lims/issues/396
             logger.warn("get_tool::getToolByName({}, '{}') failed: {} "
                         "-> falling back to plone.api.portal.get_tool('{}')"

--- a/src/senaite/api/__init__.py
+++ b/src/senaite/api/__init__.py
@@ -1,31 +1,29 @@
 # -*- coding: utf-8 -*-
 
 import logging
-
 from Acquisition import aq_base
-from AccessControl.PermissionRole import rolesForPermissionOn
-
-from Products.CMFPlone.utils import base_hasattr
-from Products.CMFCore.interfaces import ISiteRoot
-from Products.CMFCore.interfaces import IFolderish
-from Products.Archetypes.BaseObject import BaseObject
-from Products.ZCatalog.interfaces import ICatalogBrain
-from Products.CMFPlone.utils import _createObjectByType
-from Products.CMFCore.WorkflowCore import WorkflowException
-
-from zope import globalrequest
-from zope.event import notify
-from zope.component import getUtility
-from zope.component import getMultiAdapter
-from zope.component.interfaces import IFactory
-from zope.lifecycleevent import modified
-from zope.lifecycleevent import ObjectCreatedEvent
-from zope.security.interfaces import Unauthorized
-
 from plone import api as ploneapi
+from zope import globalrequest
+
+from AccessControl.PermissionRole import rolesForPermissionOn
+from Products.Archetypes.BaseObject import BaseObject
+from Products.CMFCore.WorkflowCore import WorkflowException
+from Products.CMFCore.interfaces import IFolderish
+from Products.CMFCore.interfaces import ISiteRoot
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
+from Products.CMFPlone.utils import base_hasattr
+from Products.ZCatalog.interfaces import ICatalogBrain
 from plone.api.exc import InvalidParameterError
-from plone.dexterity.interfaces import IDexterityContent
 from plone.app.layout.viewlets.content import ContentHistoryView
+from plone.dexterity.interfaces import IDexterityContent
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.component.interfaces import IFactory
+from zope.event import notify
+from zope.lifecycleevent import ObjectCreatedEvent
+from zope.lifecycleevent import modified
+from zope.security.interfaces import Unauthorized
 
 logger = logging.getLogger("senaite.api")
 
@@ -123,13 +121,28 @@ def create(container, portal_type, *args, **kwargs):
     return obj
 
 
-def get_tool(name, default=_marker):
+def get_tool(name, context=None, default=_marker):
     """Get a portal tool by name
-
     :param name: The name of the tool, e.g. `portal_catalog`
     :type name: string
+    :param context: A portal object
+    :type context: ATContentType/DexterityContentType/CatalogBrain
     :returns: Portal Tool
     """
+
+    # Try first with the context
+    if context is not None:
+        try:
+            context = get_object(context)
+            return getToolByName(context, name)
+        except (BikaLIMSError, AttributeError) as e:
+            # https://github.com/senaite/bika.lims/issues/396
+            logger.warn("get_tool::getToolByName({}, '{}') failed: {} "
+                        "-> falling back to plone.api.portal.get_tool('{}')"
+                        .format(repr(context), name, repr(e), name))
+            return get_tool(name, default=default)
+
+    # Try with the plone api
     try:
         return ploneapi.portal.get_tool(name)
     except InvalidParameterError:


### PR DESCRIPTION
From https://github.com/senaite/bika.lims/pull/397:

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/396

## Current behavior before PR

`*** AttributeError: uid_catalog` occurs on AR publication after a 1.1.6 migration

Optimization of imports done.

## Desired behavior after PR is merged

Report publication works

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
