### PR TITLE
Fix Travis CI Tests

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -40,7 +40,7 @@ auto-checkout = *
 develop = .
 
 [sources]
-bika.lims = git https://github.com/bikalims/bika.lims.git branch=master
+bika.lims = git https://github.com/senaite/bika.lims.git branch=master
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -130,4 +130,5 @@ eggs = i18ndude
 
 [versions]
 setuptools =
-zc.buildout =
+zc.buildout = 2.10.0
+five.pt = 2.2.4

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,14 @@
+1.0.3 (unreleased)
+------------------
+
+- no changes yet
+
+
 1.0.2 (2017-11-24)
 ------------------
 
 - #397(bika.lims) Fix Issue-396: AttributeError: uid_catalog on AR publication
+
 
 1.0.1 (2017-09-30)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = '1.0.2'
+version = '1.0.3'
 
 
 setup(

--- a/travis.cfg
+++ b/travis.cfg
@@ -25,7 +25,9 @@ bika.lims = git https://github.com/bikalims/bika.lims.git branch=master
 
 [versions]
 Plone = 4.3.15
-zc.buildout =
+# Fix Error: Wheels are not supported
+zc.buildout = 2.10.0
+five.pt = 2.2.4
 setuptools =
 CairoSVG = 1.0.20
 Sphinx = 1.1.3


### PR DESCRIPTION
Added version pins to fix `Error: The requirement ('Zope2>=4.0a2') is not allowed by your [versions] constraint (2.13.26)`