### PR TITLE
Get full path for brains retrieved from uid catalog

### DIFF
--- a/src/senaite/api/__init__.py
+++ b/src/senaite/api/__init__.py
@@ -482,11 +482,12 @@ def get_path(brain_or_object):
     :rtype: string
     """
     if is_brain(brain_or_object):
-        path =  brain_or_object.getPath()
+        path = brain_or_object.getPath()
         portal_path = get_path(get_portal())
         if portal_path not in path:
             return "{}/{}".format(portal_path, path)
-    return "/".join(brain_or_object.getPhysicalPath())
+        return path
+    return "/".join(get_object(brain_or_object).getPhysicalPath())
 
 
 def get_parent_path(brain_or_object):

--- a/src/senaite/api/__init__.py
+++ b/src/senaite/api/__init__.py
@@ -473,7 +473,7 @@ def get_object_by_path(path, default=_marker):
     return get_object(res[0])
 
 
-def get_path(brain_or_object):
+def get_path(brain_or_object, include_portal_path=False):
     """Calculate the physical path of this object
 
     :param brain_or_object: A single catalog brain or content object
@@ -482,8 +482,11 @@ def get_path(brain_or_object):
     :rtype: string
     """
     if is_brain(brain_or_object):
-        return brain_or_object.getPath()
-    return "/".join(get_object(brain_or_object).getPhysicalPath())
+        path =  brain_or_object.getPath()
+        portal_path = get_path(get_portal())
+        if portal_path not in path:
+            return "{}/{}".format(portal_path, path)
+    return "/".join(brain_or_object.getPhysicalPath())
 
 
 def get_parent_path(brain_or_object):

--- a/src/senaite/api/__init__.py
+++ b/src/senaite/api/__init__.py
@@ -473,7 +473,7 @@ def get_object_by_path(path, default=_marker):
     return get_object(res[0])
 
 
-def get_path(brain_or_object, include_portal_path=False):
+def get_path(brain_or_object):
     """Calculate the physical path of this object
 
     :param brain_or_object: A single catalog brain or content object


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The path of the brains obtained from a query to `uid_catalog` did not contain the portal (site) name. However, this info is needed when we want to get the object.  

## Current behavior before PR

The path didn't include the portal (site) name.

## Desired behavior after PR is merged

The path includes the portal (site) name.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html