### PR TITLE
Remove is relationship object function from API

### DIFF
--- a/src/senaite/api/__init__.py
+++ b/src/senaite/api/__init__.py
@@ -251,18 +251,6 @@ def is_folderish(brain_or_object):
     return IFolderish.providedBy(get_object(brain_or_object))
 
 
-def is_relationship_object(brain_or_object):
-    """Checks if the passed in brain or object is a relationship object
-
-    :param brain_or_object: A single catalog brain or content object
-    :return: True if the object is a relationship object
-    """
-    parent = get_parent(brain_or_object)
-    if hasattr(parent, 'id') and parent.id == "at_references":
-        return True
-    return False
-
-
 def get_portal_type(brain_or_object):
     """Get the portal type for this object
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Remove the function 'is_relationship_object' from the api. 

This is because the function was only used by the JSON API during a fetching process for `senaite.sync`. So it makes more sense to have this function in `senaite.jsonapi` than in `senaite.api`. 

## Current behavior before PR

`is_relationship_object` lives in `senaite.api`.

## Desired behavior after PR is merged

`is_relationship_object` no longer lives in `senaite.api`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html