### PR TITLE
Path info is broken for objects.

### DIFF
--- a/src/senaite/api/__init__.py
+++ b/src/senaite/api/__init__.py
@@ -487,7 +487,7 @@ def get_path(brain_or_object):
         if portal_path not in path:
             return "{}/{}".format(portal_path, path)
         return path
-    return "/".join(get_object(brain_or_object).getPhysicalPath())
+    return "/{}".format(get_object(brain_or_object).getPhysicalPath())
 
 
 def get_parent_path(brain_or_object):


### PR DESCRIPTION
Path attribute is returned wrong for `objects`.
An issue was thought to be happening on `jsonapi` which actually didn't.
See: https://github.com/senaite/senaite.jsonapi/issues/20